### PR TITLE
Improve WhatsApp message formatting

### DIFF
--- a/whatsapp_script.py
+++ b/whatsapp_script.py
@@ -8,6 +8,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+import pyperclip
+from collections import defaultdict
 
 # ========== CONFIGURATION ==========
 SHEET_NAME           = 'AUTOMATIC ORDER CONFIRMATION'  
@@ -78,6 +80,20 @@ def group_by_customer(pending):
         groups.setdefault(name, []).append((row, rec))
     return groups
 
+def aggregate_items(entries):
+    """Combine rows with the same item name and sum their quantities."""
+    item_totals = defaultdict(int)
+    for _, rec in entries:
+        try:
+            qty = int(rec['Lineitem Quantity'])
+        except Exception:
+            try:
+                qty = int(float(rec['Lineitem Quantity']))
+            except Exception:
+                qty = 0
+        item_totals[rec['Lineitem Name']] += qty
+    return [(name, qty) for name, qty in item_totals.items()]
+
 def open_whatsapp_chat(phone):
     driver.get(f"https://web.whatsapp.com/send?phone={phone}")
     print(f"🔄 Opening chat for {phone}")
@@ -107,11 +123,11 @@ ASH Homes Customer Support"""
         box.click()
         time.sleep(0.5)
 
-        for i, line in enumerate(msg.split("\n")):
-            box.send_keys(line)
-            if i < msg.count("\n"):
-                box.send_keys(Keys.SHIFT, Keys.ENTER)
+        # Paste the message in one go to avoid mis-typed newlines
+        pyperclip.copy(msg)
+        box.send_keys(Keys.CONTROL, 'v')
         box.send_keys(Keys.ENTER)
+        send_confirmation_poll()
 
         print(f"✅ Sent to {phone}")
         for r in rows:
@@ -124,6 +140,38 @@ ASH Homes Customer Support"""
             sheet.update_cell(r, 7, "Failed ❌")
             time.sleep(0.2)
 
+def send_confirmation_poll():
+    """Create a simple Yes/No poll to confirm the order."""
+    try:
+        attach_btn = wait.until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, "span[data-icon='clip']"))
+        )
+        attach_btn.click()
+
+        poll_btn = wait.until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, "button[title='Poll']"))
+        )
+        poll_btn.click()
+
+        question = wait.until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, "div[contenteditable='true'][data-testid='poll-question']"))
+        )
+        question.send_keys("Have you confirmed your order?")
+
+        options = wait.until(
+            EC.presence_of_all_elements_located((By.CSS_SELECTOR, "div[contenteditable='true'][data-testid='poll-create-option']"))
+        )
+        if len(options) >= 2:
+            options[0].send_keys("Yes")
+            options[1].send_keys("No")
+
+        send_btn = wait.until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, "span[data-icon='send']"))
+        )
+        send_btn.click()
+    except Exception as e:
+        print(f"⚠️ Could not send poll: {e}")
+
 def process_orders():
     while True:
         pending = get_pending_orders()
@@ -133,10 +181,7 @@ def process_orders():
             groups = group_by_customer(pending)
             for name, entries in groups.items():
                 rows  = [r for r, _ in entries]
-                items = [
-                    (rec['Lineitem Name'], rec['Lineitem Quantity'])
-                    for _, rec in entries
-                ]
+                items = aggregate_items(entries)
                 total = sum(float(rec['Total']) for _, rec in entries)
                 phone = "+92" + str(entries[0][1]['Shipping Phone'])[-10:]
                 send_whatsapp_message(name, items, total, phone, rows)


### PR DESCRIPTION
## Summary
- aggregate repeated line items and add helper to send yes/no poll
- paste message via clipboard so newlines are handled cleanly
- send a confirmation poll after each message

## Testing
- `python3 -m py_compile whatsapp_script.py`

------
https://chatgpt.com/codex/tasks/task_e_684759dd16c48333a6a85de2b4555482